### PR TITLE
Add service-ip-ranges module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@
 
 Terraform package to mange useful data modules via HTTP provider.
 
+- [service-ip-ranges](./modules/service-ip-ranges)
+
+
+## Usage
+
+### Service IP Ranges
+
+```tf
+module "scalr_service_ip_ranges" {
+  source  = "tedilabs/modules/http//modules/service-ip-ranges"
+  version = "~> 0.1.0"
+
+  service = "SCALR"
+}
+```
+
+
+## Examples
+
+- [service-ip-ranges](./examples/service-ip-ranges)
+
 
 ## Self Promotion
 

--- a/examples/service-ip-ranges/main.tf
+++ b/examples/service-ip-ranges/main.tf
@@ -1,0 +1,18 @@
+locals {
+  services = ["SCALR"]
+}
+
+
+###################################################
+# Service IP Ranges
+###################################################
+
+module "service_ip_ranges" {
+  source = "../../modules/service-ip-ranges"
+  # source  = "tedilabs/modules/http//modules/service-ip-ranges"
+  # version = "~> 0.1.0"
+
+  for_each = toset(local.services)
+
+  service = each.value
+}

--- a/examples/service-ip-ranges/outputs.tf
+++ b/examples/service-ip-ranges/outputs.tf
@@ -1,0 +1,6 @@
+output "cidrs" {
+  value = {
+    for k, v in module.service_ip_ranges :
+    k => v.cidrs
+  }
+}

--- a/examples/service-ip-ranges/versions.tf
+++ b/examples/service-ip-ranges/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/service-ip-ranges/README.md
+++ b/modules/service-ip-ranges/README.md
@@ -1,0 +1,41 @@
+# service-ip-ranges
+
+This module does not create any resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_http"></a> [http](#provider\_http) | 3.2.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [http_http.scalr](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_service"></a> [service](#input\_service) | (Required) The service which owns the IP ranges. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cidrs"></a> [cidrs](#output\_cidrs) | The list of IP CIDRs for the service. |
+| <a name="output_service"></a> [service](#output\_service) | The service which owns the IP ranges. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/service-ip-ranges/main.tf
+++ b/modules/service-ip-ranges/main.tf
@@ -1,0 +1,25 @@
+locals {
+  services = {
+    "SCALR" = local.scalr_cidrs
+  }
+  cidrs = local.services[var.service]
+}
+
+
+###################################################
+# IP Ranges for Scalr
+###################################################
+
+data "http" "scalr" {
+  count = var.service == "SCALR" ? 1 : 0
+
+  url = "https://scalr.io/.well-known/allowlist.txt"
+}
+
+locals {
+  scalr_ip_addresses = try(split("\n", trimspace(data.http.scalr[0].response_body)), [])
+  scalr_cidrs = [
+    for ip in local.scalr_ip_addresses :
+    "${ip}/32"
+  ]
+}

--- a/modules/service-ip-ranges/outputs.tf
+++ b/modules/service-ip-ranges/outputs.tf
@@ -1,0 +1,9 @@
+output "service" {
+  description = "The service which owns the IP ranges."
+  value       = var.service
+}
+
+output "cidrs" {
+  description = "The list of IP CIDRs for the service."
+  value       = local.cidrs
+}

--- a/modules/service-ip-ranges/variables.tf
+++ b/modules/service-ip-ranges/variables.tf
@@ -1,0 +1,9 @@
+variable "service" {
+  description = "(Required) The service which owns the IP ranges."
+  type        = string
+
+  validation {
+    condition     = contains(["SCALR"], var.service)
+    error_message = "Valid values for `service` are `SCALR`."
+  }
+}

--- a/modules/service-ip-ranges/versions.tf
+++ b/modules/service-ip-ranges/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0.0"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `service-ip-ranges` module to easily get IP ranges for service providers.