### PR TITLE
docs(readme): align example module versions with the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,26 @@ Terraform package to mange useful data modules via HTTP provider.
 ```tf
 module "okta_ip_ranges" {
   source  = "tedilabs/modules/http//modules/service-ip-ranges"
-  version = "~> 0.1.0"
+  version = "~> 0.3.0"
 
   service = "OKTA"
 }
 
 module "scalr_ip_ranges" {
   source  = "tedilabs/modules/http//modules/service-ip-ranges"
-  version = "~> 0.1.0"
+  version = "~> 0.3.0"
 
   service = "SCALR"
 }
 
-module "terraform_cloud_api_ip_ranges" {
+module "terraform_cloud_ip_ranges" {
   source  = "tedilabs/modules/http//modules/service-ip-ranges"
-  version = "~> 0.1.0"
+  version = "~> 0.3.0"
 
   service = "TERRAFORM_CLOUD"
-  category = "api"
+
+  # Ranges are returned per category, e.g. the `api` category is available as
+  # `module.terraform_cloud_ip_ranges.ipv4_cidrs["api"]`.
 }
 ```
 


### PR DESCRIPTION
## 1. What & why

The HCL blocks under `## Usage` in the root `README.md` are copy-paste documentation. They are
pinned by registry address + `version` constraint, so a stale pin sends readers to an old release
whose interface may not match the example body at all.

This PR realigns those examples to the latest release and the house `~> MAJOR.MINOR.0` convention.

Resolved latest tag: **`v0.3.0`** (`git tag --sort=-v:refname | head -1`), so the house constraint
is `~> 0.3.0`. This also matches the constraint the repo's own `examples/service-ip-ranges/main.tf`
already carries in its commented-out registry-source variant.

**One of the three examples was not merely stale — it was broken.** See §3.

Docs-only: the diff touches `README.md` and nothing else. No `*.tf` file, no `examples/` directory,
and none of the terraform-docs generated `## Requirements` / `## Providers` / `## Inputs` tables.

## 2. Changed examples

| Example block | Module | Before | After |
| --- | --- | --- | --- |
| `module "okta_ip_ranges"` (`service = "OKTA"`) | `modules/service-ip-ranges` | `~> 0.1.0` | `~> 0.3.0` |
| `module "scalr_ip_ranges"` (`service = "SCALR"`) | `modules/service-ip-ranges` | `~> 0.1.0` | `~> 0.3.0` |
| `module "terraform_cloud_api_ip_ranges"` → `module "terraform_cloud_ip_ranges"` (`service = "TERRAFORM_CLOUD"`) | `modules/service-ip-ranges` | `~> 0.1.0` | `~> 0.3.0` |

Three version lines changed; **one block's HCL also changed** (the third).

## 3. Interface drift between the pinned and latest version

### `modules/service-ip-ranges` — `~> 0.1.0` → `~> 0.3.0`

Old constraint `~> 0.1.0` resolves to **`v0.1.0`** (the only 0.1.x tag). Diff range
`v0.1.0..v0.3.0`:
https://github.com/tedilabs/terraform-http-modules/compare/v0.1.0...v0.3.0

**Verdict: substantial drift. Two blocks needed only the version bump; the third also needed an
HCL fix, because it passes an argument that no longer exists.**

`variables.tf` has exactly one variable at `v0.3.0` — `service` — and two things changed on the way
there:

**(a) The `service` validation list was widened.** This one is a happy accident in the examples'
favour, and worth checking explicitly since a narrowed list would have invalidated two of the three
blocks. At `v0.1.0`:

```tf
condition     = contains(["SCALR"], var.service)
error_message = "Valid values for `service` are `SCALR`."
```

At `v0.3.0`:

```tf
condition = contains([
  "ATLASSIAN", "CHECKLY", "GITHUB", "OKTA", "SCALR", "TERRAFORM_CLOUD",
], var.service)
```

So `"OKTA"` and `"TERRAFORM_CLOUD"` — two of the three examples — were **never valid at the version
the README told readers to pin**; only `"SCALR"` was. The list only ever grew, so all three values
are valid at `v0.3.0`. `service` also gained `nullable = false`, which is immaterial here since all
three examples pass a literal string.

**(b) The `category` variable was added and then removed again — and the README example was written
against that transient middle state.** Tracing it tag by tag
(`git show <tag>:modules/service-ip-ranges/variables.tf`):

| Tag | Variables |
| --- | --- |
| `v0.1.0` | `service` |
| `v0.2.0` – `v0.2.2` | `service`, `category` |
| `v0.3.0` | `service` |

`category` was dropped in commit `df08084` (`feat(service-ip-ranges): remove `category` variable`).
The third README block passes `category = "api"`, so it was invalid at **both** ends of its own
range: at its pinned `v0.1.0` the variable did not exist yet, and at `v0.3.0` it no longer exists.
It was only ever correct for `v0.2.x`, which the README never pointed at.

This is not a theoretical concern — the unmodified block fails at `terraform init`:

```
Error: Unsupported argument
  on main.tf line 5, in module "terraform_cloud_api_ip_ranges":
   5:   category = "api"
An argument named "category" is not expected here.
```

Before:

```tf
module "terraform_cloud_api_ip_ranges" {
  source  = "tedilabs/modules/http//modules/service-ip-ranges"
  version = "~> 0.1.0"

  service = "TERRAFORM_CLOUD"
  category = "api"
}
```

After:

```tf
module "terraform_cloud_ip_ranges" {
  source  = "tedilabs/modules/http//modules/service-ip-ranges"
  version = "~> 0.3.0"

  service = "TERRAFORM_CLOUD"

  # Ranges are returned per category, e.g. the `api` category is available as
  # `module.terraform_cloud_ip_ranges.ipv4_cidrs["api"]`.
}
```

Rationale for each part of that rewrite, since it is more than a version bump:

- **Dropping `category`** is forced — the argument does not exist. `df08084` replaced input-side
  filtering with output-side keying: `outputs.tf` lost the flat `cidrs` output and gained
  `categories`, `all_ipv4_cidrs`, `all_ipv6_cidrs`, and `ipv4_cidrs` / `ipv6_cidrs`, the latter two
  being maps keyed by category. This mirrors how `examples/service-ip-ranges/main.tf` was updated in
  the same commit, which went from a `{service, category}` product list to a plain
  `toset(["ATLASSIAN", …])` over `service` alone — so this follows the pattern already established
  in-repo rather than inventing one.
- **Renaming the label** `terraform_cloud_api_ip_ranges` → `terraform_cloud_ip_ranges`, because
  without `category` the block no longer returns only the `api` ranges and the old label would
  actively mislead a reader who copied it.
- **Adding the comment** rather than a fourth argument. The whole point of this third block, versus
  the two above it, was to demonstrate category filtering. Deleting `category` with nothing in its
  place would reduce it to a near-duplicate of the OKTA/SCALR blocks and silently drop the one thing
  it was there to teach. A comment preserves that intent without adding arguments the example never
  meant to demonstrate — happy to drop it if you'd rather the README stayed minimal.

No output referenced by any of the three examples was removed, because none of them reference
outputs. Note for anyone else auditing this module: the flat `cidrs` output **was** removed in this
range, so downstream `module.x.cidrs` references elsewhere would break — just not from this README.

## 4. Verification

Each of the three example blocks was proven, not eyeballed.

- **In-repo module == released module.** `git diff v0.3.0 origin/main -- modules/` is **empty**, so
  the module source at `origin/main` is byte-identical to the `v0.3.0` release. Validating against
  a relative in-repo path is therefore a faithful proxy for validating against the published
  `~> 0.3.0` release.
- **Per-block `terraform init -backend=false && terraform validate`.** For each block, a throwaway
  root module was built outside the repo (in a scratch dir, never committed): the README block
  copied verbatim into `main.tf` with only `source` repointed at the in-repo module via a relative
  path, plus a `versions.tf` satisfying the floors the module itself declares. Those floors were
  read off `modules/service-ip-ranges/versions.tf` rather than assumed — this is a non-AWS module,
  and it requires `hashicorp/http >= 3.5.0` with `required_version >= 1.12`; no `aws` provider is
  involved anywhere.

  All three returned `Success! The configuration is valid.` — Terraform v1.15.6, darwin_arm64.

- **Negative control.** The third block was *also* run in its unmodified form, to confirm the fix
  addresses a real failure rather than a suspected one. It fails at `init` with
  `An argument named "category" is not expected here.` (quoted in §3). That failure is what this PR
  removes.

- **Not verified, deliberately:** no `terraform plan` and no `terraform apply` was run. The module
  is pure `http` data sources against live public endpoints (Atlassian, Checkly, GitHub, Okta,
  Scalr, Terraform Cloud), so a plan would reach out over the network and its result would depend on
  those endpoints being up. That also means one thing here is genuinely unprovable at validate time:
  whether the `api` key cited in the new comment is present in
  `ipv4_cidrs` for `TERRAFORM_CLOUD` depends on the live response shape. It is asserted from
  `main.tf`, which builds the Terraform Cloud map straight from the upstream payload's own keys, and
  from the pre-`df08084` example which used `category = "api"` for exactly this service — but no
  network call was made to confirm it.

## 5. Relationship to other open PRs

Unlike the sibling repos in this sweep, **this repo has no companion `*.tf` PR**. The earlier
`chore(deps)` sweep over `*.tf` child-module version constraints found this repo's single `*.tf`
child module reference already current, so there was nothing to bump and no PR was opened. This
docs-only PR therefore stands alone here — there is no cross-reference to make.

The only other open PR is a Dependabot GitHub Actions bump (#29, `actions/checkout` 6 → 7), which is
unrelated and touches disjoint files.
